### PR TITLE
updates for pes and testlist for noresm

### DIFF
--- a/cime_config/buildnml
+++ b/cime_config/buildnml
@@ -48,23 +48,16 @@ _CISM_CONFIG_GROUPS = ["grid", "glad_climate", "esm_output", "options", "sigma",
 # we use an OrderedDict to get reliable ordering (this is unnecessary in python3.6 and
 # later because standard dicts maintain order, but necessary for 3.5 and earlier)
 #
-# It is important that this ordering be consistent with the ordering of grids in CIME's config_grids xml file.
+# It is important that this ordering be consistent with the ordering of grids in the
+# config_grids xml file (e.g., if the Antarctica grid is listed before the Greenland grid
+# in grids defined in that file, then Antarctica must appear before Greenland in this
+# variable).
 #
 # Problems may arise if one ice sheet's name is a prefix of another (e.g., "gris" and "grisa").
 #
-# If you add a new ice sheet here, you should also add entries in the following:
-#
-# Required:
-# - cime_config/config_component.xml (xml variables for each ice sheet and their
-#   relationship to compset names; follow the examples of other ice sheets there)
-# - cime_config/namelist_definition_cism.xml (defaults for this ice sheet for ice
-#   sheet-specific variables)
-# - cime_config/config_archive.xml (add a new rpointer section for the new ice sheet, as
-#   well as rpointer test file entries for this new ice sheet)
-#
-# Optional:
-# - cime_config/config_compsets.xml (compset aliases using your new ice sheet)
-# - cime_config/config_pes.xml (default processor layouts for your new ice sheet)
+# If you add a new ice sheet here, you should also add references to the new ice sheet in
+# a number of other places, as described in the documentation here:
+#   https://escomp.github.io/cism-docs/cism-in-cesm/versions/master/html/new-icesheet.html
 _ICESHEET_OPTIONS = OrderedDict([('ais', 'ANTARCTICA'),
                                  ('gris', 'GREENLAND')])
 

--- a/cime_config/config_pes.xml
+++ b/cime_config/config_pes.xml
@@ -2,48 +2,54 @@
 
 <config_pes>
 
+  <!-- ===== grid: any ===== -->
+
   <grid name="any">
     <mach name="any">
       <pes pesize="any" compset="CISM2">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-1</ntasks_atm> 
-	  <ntasks_lnd>-1</ntasks_lnd>           
-	  <ntasks_rof>-1</ntasks_rof> 
-	  <ntasks_ice>-1</ntasks_ice> 
-	  <ntasks_ocn>-1</ntasks_ocn> 
-	  <ntasks_glc>-1</ntasks_glc> 
-	  <ntasks_wav>-1</ntasks_wav> 
-	  <ntasks_cpl>-1</ntasks_cpl> 
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
-	</rootpe>
+	      <comment>none</comment>
+	      <ntasks>
+	        <ntasks_atm>-1</ntasks_atm>
+	        <ntasks_lnd>-1</ntasks_lnd>
+	        <ntasks_rof>-1</ntasks_rof>
+	        <ntasks_ice>-1</ntasks_ice>
+	        <ntasks_ocn>-1</ntasks_ocn>
+	        <ntasks_glc>-1</ntasks_glc>
+	        <ntasks_wav>-1</ntasks_wav>
+	        <ntasks_cpl>-1</ntasks_cpl>
+	      </ntasks>
+	      <nthrds>
+	        <nthrds_atm>1</nthrds_atm>
+	        <nthrds_lnd>1</nthrds_lnd>
+	        <nthrds_rof>1</nthrds_rof>
+	        <nthrds_ice>1</nthrds_ice>
+	        <nthrds_ocn>1</nthrds_ocn>
+	        <nthrds_glc>1</nthrds_glc>
+	        <nthrds_wav>1</nthrds_wav>
+	        <nthrds_cpl>1</nthrds_cpl>
+	      </nthrds>
+	      <rootpe>
+	        <rootpe_atm>0</rootpe_atm>
+	        <rootpe_lnd>0</rootpe_lnd>
+	        <rootpe_rof>0</rootpe_rof>
+	        <rootpe_ice>0</rootpe_ice>
+	        <rootpe_ocn>0</rootpe_ocn>
+	        <rootpe_glc>0</rootpe_glc>
+	        <rootpe_wav>0</rootpe_wav>
+	        <rootpe_cpl>0</rootpe_cpl>
+	      </rootpe>
       </pes>
     </mach>
   </grid>
+
+  <!-- ===== grid: gris4 ===== -->
+
   <grid name="g%gris4">
+
     <mach name="any">
       <pes pesize="any" compset="CISM2">
-	<comment>none</comment>
-	<ntasks>
+	      <comment>none</comment>
+	      <ntasks>
           <ntasks_atm>-8</ntasks_atm>
           <ntasks_lnd>-8</ntasks_lnd>
           <ntasks_rof>-8</ntasks_rof>
@@ -52,35 +58,40 @@
           <ntasks_glc>-8</ntasks_glc>
           <ntasks_wav>-8</ntasks_wav>
           <ntasks_cpl>-8</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
-	</rootpe>
+	      </ntasks>
+	      <nthrds>
+	        <nthrds_atm>1</nthrds_atm>
+	        <nthrds_lnd>1</nthrds_lnd>
+	        <nthrds_rof>1</nthrds_rof>
+	        <nthrds_ice>1</nthrds_ice>
+	        <nthrds_ocn>1</nthrds_ocn>
+	        <nthrds_glc>1</nthrds_glc>
+	        <nthrds_wav>1</nthrds_wav>
+	        <nthrds_cpl>1</nthrds_cpl>
+	      </nthrds>
+	      <rootpe>
+	        <rootpe_atm>0</rootpe_atm>
+	        <rootpe_lnd>0</rootpe_lnd>
+	        <rootpe_rof>0</rootpe_rof>
+	        <rootpe_ice>0</rootpe_ice>
+	        <rootpe_ocn>0</rootpe_ocn>
+	        <rootpe_glc>0</rootpe_glc>
+	        <rootpe_wav>0</rootpe_wav>
+	        <rootpe_cpl>0</rootpe_cpl>
+	      </rootpe>
       </pes>
     </mach>
+
   </grid>
+
+  <!-- ===== grid: ais8 ===== -->
+
   <grid name="g%ais8">
+
     <mach name="any">
       <pes pesize="any" compset="CISM2">
-	<comment>none</comment>
-	<ntasks>
+	      <comment>none</comment>
+	      <ntasks>
           <ntasks_atm>-8</ntasks_atm>
           <ntasks_lnd>-8</ntasks_lnd>
           <ntasks_rof>-8</ntasks_rof>
@@ -89,102 +100,144 @@
           <ntasks_glc>-8</ntasks_glc>
           <ntasks_wav>-8</ntasks_wav>
           <ntasks_cpl>-8</ntasks_cpl>
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>
-	  <nthrds_lnd>1</nthrds_lnd>
-	  <nthrds_rof>1</nthrds_rof>
-	  <nthrds_ice>1</nthrds_ice>
-	  <nthrds_ocn>1</nthrds_ocn>
-	  <nthrds_glc>1</nthrds_glc>
-	  <nthrds_wav>1</nthrds_wav>
-	  <nthrds_cpl>1</nthrds_cpl>
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm>
-	  <rootpe_lnd>0</rootpe_lnd>
-	  <rootpe_rof>0</rootpe_rof>
-	  <rootpe_ice>0</rootpe_ice>
-	  <rootpe_ocn>0</rootpe_ocn>
-	  <rootpe_glc>0</rootpe_glc>
-	  <rootpe_wav>0</rootpe_wav>
-	  <rootpe_cpl>0</rootpe_cpl>
-	</rootpe>
+	      </ntasks>
+	      <nthrds>
+	        <nthrds_atm>1</nthrds_atm>
+	        <nthrds_lnd>1</nthrds_lnd>
+	        <nthrds_rof>1</nthrds_rof>
+	        <nthrds_ice>1</nthrds_ice>
+	        <nthrds_ocn>1</nthrds_ocn>
+	        <nthrds_glc>1</nthrds_glc>
+	        <nthrds_wav>1</nthrds_wav>
+	        <nthrds_cpl>1</nthrds_cpl>
+	      </nthrds>
+	      <rootpe>
+	        <rootpe_atm>0</rootpe_atm>
+	        <rootpe_lnd>0</rootpe_lnd>
+	        <rootpe_rof>0</rootpe_rof>
+	        <rootpe_ice>0</rootpe_ice>
+	        <rootpe_ocn>0</rootpe_ocn>
+	        <rootpe_glc>0</rootpe_glc>
+	        <rootpe_wav>0</rootpe_wav>
+	        <rootpe_cpl>0</rootpe_cpl>
+	      </rootpe>
       </pes>
     </mach>
+
   </grid>
+
+  <!-- ===== grid: gris20 ===== -->
+
   <grid name="g%gris20">
+
     <mach name="any">
       <pes pesize="any" compset="CISM2">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-2</ntasks_atm> 
-	  <ntasks_lnd>-2</ntasks_lnd>           
-	  <ntasks_rof>-2</ntasks_rof> 
-	  <ntasks_ice>-2</ntasks_ice> 
-	  <ntasks_ocn>-2</ntasks_ocn> 
-	  <ntasks_glc>-2</ntasks_glc> 
-	  <ntasks_wav>-2</ntasks_wav> 
-	  <ntasks_cpl>-2</ntasks_cpl> 
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
-	</rootpe>
+	      <comment>none</comment>
+	      <ntasks>
+	        <ntasks_atm>-2</ntasks_atm>
+	        <ntasks_lnd>-2</ntasks_lnd>
+	        <ntasks_rof>-2</ntasks_rof>
+	        <ntasks_ice>-2</ntasks_ice>
+	        <ntasks_ocn>-2</ntasks_ocn>
+	        <ntasks_glc>-2</ntasks_glc>
+	        <ntasks_wav>-2</ntasks_wav>
+	        <ntasks_cpl>-2</ntasks_cpl>
+	      </ntasks>
+	      <nthrds>
+	        <nthrds_atm>1</nthrds_atm>
+	        <nthrds_lnd>1</nthrds_lnd>
+	        <nthrds_rof>1</nthrds_rof>
+	        <nthrds_ice>1</nthrds_ice>
+	        <nthrds_ocn>1</nthrds_ocn>
+	        <nthrds_glc>1</nthrds_glc>
+	        <nthrds_wav>1</nthrds_wav>
+	        <nthrds_cpl>1</nthrds_cpl>
+	      </nthrds>
+	      <rootpe>
+	        <rootpe_atm>0</rootpe_atm>
+	        <rootpe_lnd>0</rootpe_lnd>
+	        <rootpe_rof>0</rootpe_rof>
+	        <rootpe_ice>0</rootpe_ice>
+	        <rootpe_ocn>0</rootpe_ocn>
+	        <rootpe_glc>0</rootpe_glc>
+	        <rootpe_wav>0</rootpe_wav>
+	        <rootpe_cpl>0</rootpe_cpl>
+	      </rootpe>
       </pes>
     </mach>
+
     <mach name="derecho">
       <pes pesize="any" compset="CISM2">
-	<comment>none</comment>
-	<ntasks>
-	  <ntasks_atm>-1</ntasks_atm> 
-	  <ntasks_lnd>-1</ntasks_lnd>           
-	  <ntasks_rof>-1</ntasks_rof> 
-	  <ntasks_ice>-1</ntasks_ice> 
-	  <ntasks_ocn>-1</ntasks_ocn> 
-	  <ntasks_glc>-1</ntasks_glc> 
-	  <ntasks_wav>-1</ntasks_wav> 
-	  <ntasks_cpl>-1</ntasks_cpl> 
-	</ntasks>
-	<nthrds>
-	  <nthrds_atm>1</nthrds_atm>                   
-	  <nthrds_lnd>1</nthrds_lnd> 
-	  <nthrds_rof>1</nthrds_rof> 
-	  <nthrds_ice>1</nthrds_ice> 
-	  <nthrds_ocn>1</nthrds_ocn> 
-	  <nthrds_glc>1</nthrds_glc> 
-	  <nthrds_wav>1</nthrds_wav> 
-	  <nthrds_cpl>1</nthrds_cpl> 
-	</nthrds>
-	<rootpe>
-	  <rootpe_atm>0</rootpe_atm> 
-	  <rootpe_lnd>0</rootpe_lnd> 
-	  <rootpe_rof>0</rootpe_rof> 
-	  <rootpe_ice>0</rootpe_ice>    
-	  <rootpe_ocn>0</rootpe_ocn>   
-	  <rootpe_glc>0</rootpe_glc> 
-	  <rootpe_wav>0</rootpe_wav> 
-	  <rootpe_cpl>0</rootpe_cpl>                         
-	</rootpe>
+	      <comment>none</comment>
+	      <ntasks>
+	        <ntasks_atm>-1</ntasks_atm>
+	        <ntasks_lnd>-1</ntasks_lnd>
+	        <ntasks_rof>-1</ntasks_rof>
+	        <ntasks_ice>-1</ntasks_ice>
+	        <ntasks_ocn>-1</ntasks_ocn>
+	        <ntasks_glc>-1</ntasks_glc>
+	        <ntasks_wav>-1</ntasks_wav>
+	        <ntasks_cpl>-1</ntasks_cpl>
+	      </ntasks>
+	      <nthrds>
+	        <nthrds_atm>1</nthrds_atm>
+	        <nthrds_lnd>1</nthrds_lnd>
+	        <nthrds_rof>1</nthrds_rof>
+	        <nthrds_ice>1</nthrds_ice>
+	        <nthrds_ocn>1</nthrds_ocn>
+	        <nthrds_glc>1</nthrds_glc>
+	        <nthrds_wav>1</nthrds_wav>
+	        <nthrds_cpl>1</nthrds_cpl>
+	      </nthrds>
+	      <rootpe>
+	        <rootpe_atm>0</rootpe_atm>
+	        <rootpe_lnd>0</rootpe_lnd>
+	        <rootpe_rof>0</rootpe_rof>
+	        <rootpe_ice>0</rootpe_ice>
+	        <rootpe_ocn>0</rootpe_ocn>
+	        <rootpe_glc>0</rootpe_glc>
+	        <rootpe_wav>0</rootpe_wav>
+	        <rootpe_cpl>0</rootpe_cpl>
+	      </rootpe>
       </pes>
     </mach>
+
+    <mach name="betzy">
+      <pes pesize="any" compset="CISM2">
+	      <comment>none</comment>
+	      <ntasks>
+	        <ntasks_atm>-1</ntasks_atm>
+	        <ntasks_lnd>-1</ntasks_lnd>
+	        <ntasks_rof>-1</ntasks_rof>
+	        <ntasks_ice>-1</ntasks_ice>
+	        <ntasks_ocn>-1</ntasks_ocn>
+	        <ntasks_glc>-1</ntasks_glc>
+	        <ntasks_wav>-1</ntasks_wav>
+	        <ntasks_cpl>-1</ntasks_cpl>
+	      </ntasks>
+	      <nthrds>
+	        <nthrds_atm>1</nthrds_atm>
+	        <nthrds_lnd>1</nthrds_lnd>
+	        <nthrds_rof>1</nthrds_rof>
+	        <nthrds_ice>1</nthrds_ice>
+	        <nthrds_ocn>1</nthrds_ocn>
+	        <nthrds_glc>1</nthrds_glc>
+	        <nthrds_wav>1</nthrds_wav>
+	        <nthrds_cpl>1</nthrds_cpl>
+	      </nthrds>
+	      <rootpe>
+	        <rootpe_atm>0</rootpe_atm>
+	        <rootpe_lnd>0</rootpe_lnd>
+	        <rootpe_rof>0</rootpe_rof>
+	        <rootpe_ice>0</rootpe_ice>
+	        <rootpe_ocn>0</rootpe_ocn>
+	        <rootpe_glc>0</rootpe_glc>
+	        <rootpe_wav>0</rootpe_wav>
+	        <rootpe_cpl>0</rootpe_cpl>
+	      </rootpe>
+      </pes>
+    </mach>
+
   </grid>
 
 </config_pes>
-

--- a/cime_config/testdefs/testlist_cism.xml
+++ b/cime_config/testdefs/testlist_cism.xml
@@ -1,195 +1,122 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
 
-  <test name="ERI_Ly44" grid="f09_g17_gris20" compset="T1850Gg" testmods="cism/isostasy_period4">
+  <test name="ERI_Ly44" grid="f09_tn14_gris20" compset="T1850Gg" testmods="cism/isostasy_period4">
     <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">0:40</option>
           <option name="comment">include a longer ERI test to catch problems that may just show up after longer runs, using a coarse resolution to get faster turnaround and lower cost; include isostasy because there are extra subtleties with getting isostasy to restart exactly</option>
         </options>
       </machine>
-
     </machines>
   </test>
 
-  <test name="ERI_Ly15" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/isostasy_period4">
+  <test name="ERI_Ly15" grid="f09_tn14_gris4" compset="T1850Gg" testmods="cism/isostasy_period4">
     <machines>
-
-      <machine name="derecho" compiler="intel" category="prebeta">
+      <machine name="betzy" compiler="intel" category="prebeta_noresm">
         <options>
           <option name="wallclock">0:40</option>
         </options>
       </machine>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">0:40</option>
           <option name="comment">include an ERI test at the production resolution, to exercise all options used at that resolution; include isostasy because there are extra subtleties with getting isostasy to restart exactly</option>
         </options>
       </machine>
-
     </machines>
   </test>
 
   <test name="ERS_D_Ld9" grid="f10_f10_mg37" compset="I1850Clm50SpG" testmods="cism/override_glc_frac">
     <machines>
-
-      <machine name="derecho" compiler="gnu" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">01:30:00</option>
           <option name="comment">Make sure glc override options work correctly, and restart properly. Note that we do not generate cism history files in this test, but that is okay: this test is about what is sent to the coupler, not what is output by CISM. (And currently CISM history files do not restart properly in this test.)</option>
         </options>
       </machine>
-
     </machines>
   </test>
 
-  <test name="ERS_Ly11" grid="f09_g17_gris20" compset="T1850Gg">
+  <test name="ERS_Ly11" grid="f09_tn14_gris20" compset="T1850Gg">
     <machines>
-
-      <machine name="derecho" compiler="gnu" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">0:20</option>
         </options>
       </machine>
-
     </machines>
   </test>
 
-  <test name="ERS_Ly11" grid="f09_g17_gris20" compset="T1850Gg" testmods="cism/oneway">
+  <test name="ERS_Ly11" grid="f09_tn14_gris20" compset="T1850Gg" testmods="cism/oneway">
     <machines>
-
-      <machine name="derecho" compiler="gnu" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">0:20</option>
           <option name="comment">(3-3-16) identical to an existing non-oneway test, which generates some non-zero runoff fluxes</option>
         </options>
       </machine>
-
     </machines>
   </test>
-
-  <!-- Remove mct tests as they are no longer supported -->
-  <!--test name="ERS_Vmct_D_Ly3" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/noevolve">
-    <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
-        <options>
-          <option name="wallclock">0:30</option>
-          <option name="comment">ice evolution off is the typical operation of cism within cesm, so test that configuration</option>
-        </options>
-      </machine>
-
-    </machines>
-  </test-->
 
   <!-- BUG(wjs, 2021-09-29, ESCOMP/CISM-wrapper#60) This currently fails
        at namelist generation time, with "ERROR: for TG compset require
        that lnd_cpl_time equal glc_cpl_time". If I remember correctly,
        Mariana Vertenstein has fixed this issue on a branch of CMEPS.
        Once it is working, we should restore this test. -->
-  <test name="ERS_D_Ly3" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/noevolve">
+  <test name="ERS_D_Ly3" grid="f09_tn14_gris4" compset="T1850Gg" testmods="cism/noevolve">
     <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">0:30</option>
           <option name="comment">ice evolution off is the typical operation of cism within cesm, so test that configuration</option>
         </options>
       </machine>
-
     </machines>
   </test>
 
-
-  <test name="ERS_Ly3_C2_D" grid="f09_g17_gris20" compset="T1850Gg">
+  <test name="ERS_Ly7" grid="f09_tn14_gris4" compset="T1850Gg">
     <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
-        <options>
-          <option name="wallclock">0:30</option>
-          <option name="comment">Include a CISM2 multi-instance restart test, and a multi-instance debug test</option>
-        </options>
-      </machine>
-
-      <machine name="derecho" compiler="intel" category="prebeta">
-        <options>
-          <option name="wallclock">0:30</option>
-        </options>
-      </machine>
-
-    </machines>
-  </test>
-  <test name="ERS_Ly3_C2_D" grid="f09_g17_gris20" compset="T1850Gg">
-    <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
-        <options>
-          <option name="wallclock">0:30</option>
-          <option name="comment">Include a CISM2 multi-instance restart test, and a multi-instance debug test</option>
-        </options>
-      </machine>
-
-      <machine name="derecho" compiler="intel" category="prebeta">
-        <options>
-          <option name="wallclock">0:30</option>
-        </options>
-      </machine>
-
-    </machines>
-  </test>
-
-  <test name="ERS_Ly7" grid="f09_g17_gris4" compset="T1850Gg">
-    <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">0:20</option>
           <option name="comment">include one ERS test of the typical production resolution for CISM2</option>
         </options>
       </machine>
-
-      <machine name="derecho" compiler="intel" category="prealpha">
+      <machine name="betzy" compiler="intel" category="prealpha_noresm">
         <options>
           <option name="wallclock">0:20</option>
         </options>
       </machine>
-
     </machines>
   </test>
 
-  <test name="ERS_Ly5" grid="f09_g17_ais8" compset="T1850Ga">
+  <test name="ERS_Ly5" grid="f09_tn14_ais8" compset="T1850Ga">
     <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">0:20</option>
           <option name="comment">include a non-debug T compset test of Antarctica</option>
         </options>
       </machine>
-
     </machines>
   </test>
 
-  <test name="ERS_D_Ly3" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/cmip6_evolving_icesheet">
+  <test name="ERS_D_Ly3" grid="f09_tn14_gris4" compset="T1850Gg" testmods="cism/cmip6_evolving_icesheet">
     <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">1:00</option>
           <option name="comment">Want both an ERS test and a _D test that include the cmip6_evolving_icesheet usermods</option>
         </options>
       </machine>
-
     </machines>
   </test>
 
   <test name="ERS_Ly3" grid="f10_f10_mg37" compset="I1850Clm50SpG">
     <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">1:59</option>
           <!-- 2016-10-25: There is a big jump in memory at the start of year
@@ -198,17 +125,15 @@
                prognostic solve, so I think this is expected behavior. Thus, I
                believe this is not actually a problem. -->
           <option name="memleak_tolerance">0.34</option>
-          <option name="comment">Need IG ERS test to catch problems with fields sent before the end of the first year after restart. Also note that this is the only multi-year non-TG test in the test list, so this is the one test that a production-like configuration can run for a few years.</option>
+          <option name="comment">Need IG ERS test to catch problems with fields sent before the end of the first year after restart.</option>
         </options>
       </machine>
-
     </machines>
   </test>
 
   <test name="ERS_Ly3" grid="f10_f10_ais8_mg37" compset="I1850Clm50SpGa">
     <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">1:59</option>
           <!-- 2016-10-25: Notes from similar Greenland, non-NUOPC test:
@@ -221,27 +146,23 @@
           <option name="comment">include a multi-year I compset test with Antarctica</option>
         </options>
       </machine>
-
     </machines>
   </test>
 
   <test name="SMS_Lm13" grid="f10_f10_mg37" compset="I1850Clm50SpG">
     <machines>
-
-      <machine name="derecho" compiler="intel" category="prealpha">
+      <machine name="betzy" compiler="intel" category="prealpha_noresm">
         <options>
           <option name="wallclock">2:00</option>
           <option name="comment">Include one test in the prealpha test list that exercises CISM without resorting to the test_coupling testmod, in order to exercise CISM in a production-like configuration. 13-months rather than 1-year in order to allow time for CISM to affect CLM (and CLM to produce the next month's history file).</option>
         </options>
       </machine>
-
     </machines>
   </test>
 
   <test name="ERS_Lm24" grid="f10_f10_ais8gris4_mg37" compset="I1850Clm50SpGag">
     <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">1:59:00</option>
           <!-- 2016-10-25: At least in the ERS_Ly5 test: There is a big jump in
@@ -260,8 +181,7 @@
 
   <test name="ERI_Lm24" grid="f10_f10_mg37" compset="I1850Clm50SpG" testmods="cism/isostasy_period4">
     <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">1:59</option>
           <!-- 2016-10-25: At least in the ERS_Ly5 test: There is a big jump in
@@ -274,56 +194,24 @@
           <option name="comment">Test branching mid-year; include isostasy because there are extra subtleties with getting isostasy to restart exactly</option>
         </options>
       </machine>
-
     </machines>
   </test>
 
   <test name="ERI" grid="f10_f10_mg37" compset="I1850Clm50SpG" testmods="cism/test_coupling">
     <machines>
-
-      <machine name="derecho" compiler="gnu" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">1:45</option>
           <option name="comment">Changes often break the test_coupling testmod, so include an ERI test with this testmod to help catch these problems</option>
         </options>
       </machine>
-
-    </machines>
-  </test>
-
-  <test name="NCK_Ly3" grid="f09_g17_gris20" compset="T1850Gg">
-    <machines>
-
-      <machine name="derecho" compiler="gnu" category="aux_glc">
-        <options>
-          <option name="wallclock">0:20</option>
-        </options>
-      </machine>
-
-    </machines>
-  </test>
-  <test name="MCC_Ly3" grid="f09_g17_gris20" compset="T1850Gg">
-    <machines>
-
-      <machine name="derecho" compiler="gnu" category="prebeta">
-        <options>
-          <option name="wallclock">0:20</option>
-        </options>
-      </machine>
-
-      <machine name="derecho" compiler="gnu" category="aux_glc">
-        <options>
-          <option name="wallclock">0:20</option>
-        </options>
-      </machine>
-
     </machines>
   </test>
 
   <test name="SMS_D_Ld5" grid="f10_f10_ais8gris4_mg37" compset="I1850Clm50SpGag" testmods="cism/test_coupling">
     <machines>
 
-      <machine name="derecho" compiler="gnu" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">0:30:00</option>
           <option name="comment">Include a short debug I compset test with both Antarctica and Greenland (basically duplicates a test on izumi, so we don't need to do baseline comparisons on izumi)</option>
@@ -333,236 +221,101 @@
     </machines>
   </test>
 
-  <test name="SMS_D_Ld5_P24x1" grid="f10_f10_ais8gris4_mg37" compset="I1850Clm50SpGag" testmods="cism/test_coupling">
+  <test name="SMS_D_Ly1" grid="f09_tn14_gris4" compset="T1850Gg" testmods="cism/isostasy_period1">
     <machines>
-
-      <machine name="izumi" compiler="nag" category="aux_glc">
-        <options>
-          <option name="wallclock">1:59:00</option>
-          <option name="comment">IG nag debug test with both Antarctica and Greenland, to check logic for fields sent from glc to lnd</option>
-        </options>
-      </machine>
-
-      <machine name="izumi" compiler="nag" category="prealpha">
-        <options>
-          <option name="wallclock">1:59:00</option>
-        </options>
-      </machine>
-
-    </machines>
-  </test>
-
-  <test name="SMS_D_Ly1" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/isostasy_period1">
-    <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">0:20</option>
           <option name="comment">Include a debug test with isostasy turned on</option>
         </options>
       </machine>
-
     </machines>
   </test>
 
-  <test name="SMS_D_Ly1" grid="f09_g17_gris4" compset="T1850Gg">
+  <test name="SMS_D_Ly1" grid="f09_tn14_gris4" compset="T1850Gg">
     <machines>
-
-      <machine name="derecho" compiler="gnu" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">0:20</option>
         </options>
       </machine>
-
+      <machine name="betzy" compiler="intel" category="prebeta_noresm">
+        <options>
+          <option name="wallclock">0:20</option>
+        </options>
+      </machine>
     </machines>
   </test>
 
-  <test name="SMS_D_Ly1" grid="f09_g17_gris4" compset="T1850Gg">
+  <test name="SMS_D_Ly1" grid="f09_tn14_ais8" compset="T1850Ga">
     <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">0:20</option>
+          <option name="comment">include a debug T compset test with Antarctica, gnu compiler (currently changed to intel for betzy)</option>
         </options>
       </machine>
-
-      <machine name="derecho" compiler="intel" category="prebeta">
-        <options>
-          <option name="wallclock">0:20</option>
-        </options>
-      </machine>
-
-    </machines>
-  </test>
-
-  <test name="SMS_D_Ly1" grid="f09_g17_ais8" compset="T1850Ga">
-    <machines>
-
-      <machine name="derecho" compiler="gnu" category="aux_glc">
-        <options>
-          <option name="wallclock">0:20</option>
-          <option name="comment">include a debug T compset test with Antarctica, gnu compiler</option>
-        </options>
-      </machine>
-
-      <machine name="derecho" compiler="gnu" category="prealpha">
+      <machine name="betzy" compiler="intel" category="prealpha_noresm">
         <options>
           <option name="wallclock">0:20</option>
           <option name="comment">include an Antarctica test in the prealpha suite</option>
         </options>
       </machine>
-
-    </machines>
-  </test>
-  <test name="SMS_D_Ly1" grid="f09_g17_ais8" compset="T1850Ga">
-    <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
-        <options>
-          <option name="wallclock">0:20</option>
-          <option name="comment">include a debug T compset test with Antarctica, intel compiler</option>
-        </options>
-      </machine>
-
     </machines>
   </test>
 
-  <test name="SMS_D_Ly1_P24x1" grid="f09_g17_gris4" compset="T1850Gg">
+  <test name="ERS_Ly5" grid="f09_tn14_gris4" compset="T1850Gg" testmods="cism/isostasy_period4">
     <machines>
-
-      <machine name="izumi" compiler="nag" category="aux_glc">
-        <options>
-          <option name="wallclock">1:59</option>
-          <option name="comment">short nag debug test of CISM2 at production resolution, to test options specific to the production resolution (currently, which_ho_babc differs at the production resolution)</option>
-        </options>
-      </machine>
-
-    </machines>
-  </test>
-
-  <test name="SMS_D_Ly1_P24x1" grid="f09_g17_ais8" compset="T1850Ga">
-    <machines>
-
-      <machine name="izumi" compiler="nag" category="aux_glc">
-        <options>
-          <option name="wallclock">1:59</option>
-          <option name="comment">short nag debug T compset test of CISM2 with Antarctica</option>
-        </options>
-      </machine>
-
-    </machines>
-  </test>
-  
-  <test name="SMS_D_Ly3_P24x1" grid="f09_g17_gris20" compset="T1850Gg">
-    <machines>
-
-      <machine name="izumi" compiler="nag" category="aux_glc">
-        <options>
-          <option name="wallclock">1:59</option>
-          <option name="comment">multi-year nag debug test of CISM2 at coarse resolution</option>
-        </options>
-      </machine>
-
-    </machines>
-  </test>
-  
-  <test name="ERS_Ly5" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/isostasy_period4">
-    <machines>
-
-      <machine name="derecho" compiler="gnu" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">1:30</option>
           <option name="comment">Include an exact restart test with isostasy, where we restart in the middle of the isostasy update period</option>
         </options>
       </machine>
-
     </machines>
   </test>
 
-  <test name="ERS_Ly3" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/isostasy_period1">
+  <test name="ERS_Ly3" grid="f09_tn14_gris4" compset="T1850Gg" testmods="cism/isostasy_period1">
     <machines>
-
-      <machine name="derecho" compiler="gnu" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">0:50</option>
           <option name="comment">Include an exact restart test with isostasy, where restart aligns with the isostasy update period</option>
         </options>
       </machine>
-
     </machines>
   </test>
 
   <test name="SMS_Lm13" grid="f10_f10_mg37" compset="I1850Clm50SpG" testmods="cism/noevolve">
     <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">2:00</option>
           <option name="comment">Include an I compset test with CISM in NOEVOLVE mode. The purpose of this test is: Often there are answer changes in CISM, but we expect that these should not affect NOEVOLVE runs (which is the typical CESM configuration). This test allows us to do a baseline comparison to confirm that expectation. 13-months rather than 1-year in order to allow time for CISM to affect CLM (and CLM to produce the next month's history file).</option>
         </options>
       </machine>
-
     </machines>
   </test>
 
-  <test name="ERS_D_Ly3" grid="f09_g17_ais8gris4" compset="T1850Gag">
+  <test name="ERS_D_Ly3" grid="f09_tn14_ais8gris4" compset="T1850Gag">
     <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">1:00:00</option>
           <option name="comment">Include an ERS_D test with multiple ice sheets</option>
         </options>
       </machine>
-
     </machines>
   </test>
 
-  <test name="ERI_C2_Ly9" grid="f09_g17_ais8gris4" compset="T1850Gag">
+  <test name="ERI_Ly9" grid="f09_tn14_ais8gris4" compset="T1850Gag" testmods="cism-noevolve_ais">
     <machines>
-
-      <machine name="derecho" compiler="gnu" category="aux_glc">
-        <options>
-          <option name="wallclock">0:50:00</option>
-          <option name="comment">This test covers a lot of things we want: (1) a multi-instance ERI test (to catch problems with multi-instance branch/hybrid runs); (2) a multi-ice sheet ERI test; (3) a multi-instance multi-ice sheet test.</option>
-        </options>
-      </machine>
-
-    </machines>
-  </test>
-
-  <test name="ERI_Ly9" grid="f09_g17_ais8gris4" compset="T1850Gag" testmods="cism-noevolve_ais">
-    <machines>
-
-      <machine name="derecho" compiler="gnu" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">0:50:00</option>
           <option name="comment">ERI test with one ice sheet evolving and the other not, to make sure restart, branch and hybrid runs all work when one ice sheet is evolving and another is not.</option>
         </options>
       </machine>
-
-    </machines>
-  </test>
-
-  <test name="IRT_Ly5_P24x1" grid="f09_g17_ais8gris4" compset="T1850Gag">
-    <machines>
-
-      <!-- BUG(wjs, 2021-10-20, ESMCI/cime#3978) I wanted this test to
-           be on cheyenne_gnu. However, IRT tests are currently failing
-           in the GENERATE phase (and presumably would fail in the
-           COMPARE phase, too). So for now I'm putting this test on
-           izumi_nag, since we don't do baseline generation or
-           comparison on izumi. Once ESMCI/cime#3978 is resolved,
-           probably move this back to cheyenne_gnu (though it isn't
-           really critical for baseline generation and comparison to be
-           done with this test). -->
-      <machine name="izumi" compiler="nag" category="aux_glc">
-        <options>
-          <option name="wallclock">0:30:00</option>
-          <option name="comment">Include a multi-ice sheet IRT test to test saving and restoring interim restart files to/from the archive (partly because the specification of interim restart file patterns for multiple ice sheets in config_archive.xml is a bit tricky).</option>
-        </options>
-      </machine>
-
     </machines>
   </test>
 
@@ -582,15 +335,13 @@
   -->
   <test name="MULTINOAIS_Ly2" grid="f10_f10_ais8gris4_mg37" compset="I1850Clm50SpRsGag" testmods="cism/change_params">
     <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">1:50:00</option>
           <option name="comment">Compare a run with Antarctica and Greenland against a run with just Greenland; Greenland should be bit-for-bit in the two runs. Using an I compset test to exercise smb renormalization as well as code related to glc -> lnd coupling. The use of the change_params testmod is not critical for this test, but this test is a useful one for exercising that testmod.</option>
         </options>
       </machine>
-
-      <machine name="derecho" compiler="intel" category="prealpha">
+      <machine name="betzy" compiler="intel" category="prealpha_noresm">
         <options>
           <option name="wallclock">1:50:00</option>
           <option name="comment">Compare a run with Antarctica and Greenland against a run with just Greenland; Greenland should be bit-for-bit in the two runs. Using an I compset test to exercise smb renormalization as well as code related to glc -> lnd coupling. The use of the change_params testmod is not critical for this test, but this test is a useful one for exercising that testmod.</option>
@@ -601,14 +352,12 @@
   </test>
   <test name="MULTINOGRIS_Ly2" grid="f10_f10_ais8gris4_mg37" compset="I1850Clm50SpRsGag" testmods="cism/change_params">
     <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_glc">
+      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
         <options>
           <option name="wallclock">1:50:00</option>
           <option name="comment">Compare a run with Antarctica and Greenland against a run with just Antarctica; Antarctica should be bit-for-bit in the two runs. Using an I compset test to exercise smb renormalization as well as code related to glc -> lnd coupling. The use of the change_params testmod is not critical for this test, but this test is a useful one for exercising that testmod.</option>
         </options>
       </machine>
-
     </machines>
   </test>
 
@@ -621,27 +370,23 @@
        ice sheets.
   -->
 
-  <test name="SMS_Ly2" grid="f09_g17_gris20" compset="T1850Gg">
+  <test name="SMS_Ly2" grid="f09_tn14_gris20" compset="T1850Gg">
     <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_cime_baselines">
+      <machine name="betzy" compiler="intel" category="aux_cime_baselines">
         <options>
           <option name="wallclock">0:30:00</option>
         </options>
       </machine>
-
     </machines>
   </test>
 
   <test name="SMS_Ld5" grid="f10_f10_ais8gris4_mg37" compset="I1850Clm50SpGag" testmods="cism/test_coupling">
     <machines>
-
-      <machine name="derecho" compiler="intel" category="aux_cime_baselines">
+      <machine name="betzy" compiler="intel" category="aux_cime_baselines">
         <options>
           <option name="wallclock">0:30:00</option>
         </options>
       </machine>
-
     </machines>
   </test>
 

--- a/cime_config/testdefs/testlist_cism.xml
+++ b/cime_config/testdefs/testlist_cism.xml
@@ -3,7 +3,7 @@
 
   <test name="ERI_Ly44" grid="f09_tn14_gris20" compset="T1850Gg" testmods="cism/isostasy_period4">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">0:40</option>
           <option name="comment">include a longer ERI test to catch problems that may just show up after longer runs, using a coarse resolution to get faster turnaround and lower cost; include isostasy because there are extra subtleties with getting isostasy to restart exactly</option>
@@ -19,7 +19,7 @@
           <option name="wallclock">0:40</option>
         </options>
       </machine>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">0:40</option>
           <option name="comment">include an ERI test at the production resolution, to exercise all options used at that resolution; include isostasy because there are extra subtleties with getting isostasy to restart exactly</option>
@@ -30,7 +30,7 @@
 
   <test name="ERS_D_Ld9" grid="f10_f10_mg37" compset="I1850Clm50SpG" testmods="cism/override_glc_frac">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">01:30:00</option>
           <option name="comment">Make sure glc override options work correctly, and restart properly. Note that we do not generate cism history files in this test, but that is okay: this test is about what is sent to the coupler, not what is output by CISM. (And currently CISM history files do not restart properly in this test.)</option>
@@ -41,7 +41,7 @@
 
   <test name="ERS_Ly11" grid="f09_tn14_gris20" compset="T1850Gg">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">0:20</option>
         </options>
@@ -51,7 +51,7 @@
 
   <test name="ERS_Ly11" grid="f09_tn14_gris20" compset="T1850Gg" testmods="cism/oneway">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">0:20</option>
           <option name="comment">(3-3-16) identical to an existing non-oneway test, which generates some non-zero runoff fluxes</option>
@@ -67,7 +67,7 @@
        Once it is working, we should restore this test. -->
   <test name="ERS_D_Ly3" grid="f09_tn14_gris4" compset="T1850Gg" testmods="cism/noevolve">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">0:30</option>
           <option name="comment">ice evolution off is the typical operation of cism within cesm, so test that configuration</option>
@@ -78,7 +78,7 @@
 
   <test name="ERS_Ly7" grid="f09_tn14_gris4" compset="T1850Gg">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">0:20</option>
           <option name="comment">include one ERS test of the typical production resolution for CISM2</option>
@@ -94,7 +94,7 @@
 
   <test name="ERS_Ly5" grid="f09_tn14_ais8" compset="T1850Ga">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">0:20</option>
           <option name="comment">include a non-debug T compset test of Antarctica</option>
@@ -105,7 +105,7 @@
 
   <test name="ERS_D_Ly3" grid="f09_tn14_gris4" compset="T1850Gg" testmods="cism/cmip6_evolving_icesheet">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">1:00</option>
           <option name="comment">Want both an ERS test and a _D test that include the cmip6_evolving_icesheet usermods</option>
@@ -116,7 +116,7 @@
 
   <test name="ERS_Ly3" grid="f10_f10_mg37" compset="I1850Clm50SpG">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">1:59</option>
           <!-- 2016-10-25: There is a big jump in memory at the start of year
@@ -133,7 +133,7 @@
 
   <test name="ERS_Ly3" grid="f10_f10_ais8_mg37" compset="I1850Clm50SpGa">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">1:59</option>
           <!-- 2016-10-25: Notes from similar Greenland, non-NUOPC test:
@@ -162,7 +162,7 @@
 
   <test name="ERS_Lm24" grid="f10_f10_ais8gris4_mg37" compset="I1850Clm50SpGag">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">1:59:00</option>
           <!-- 2016-10-25: At least in the ERS_Ly5 test: There is a big jump in
@@ -181,7 +181,7 @@
 
   <test name="ERI_Lm24" grid="f10_f10_mg37" compset="I1850Clm50SpG" testmods="cism/isostasy_period4">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">1:59</option>
           <!-- 2016-10-25: At least in the ERS_Ly5 test: There is a big jump in
@@ -199,7 +199,7 @@
 
   <test name="ERI" grid="f10_f10_mg37" compset="I1850Clm50SpG" testmods="cism/test_coupling">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">1:45</option>
           <option name="comment">Changes often break the test_coupling testmod, so include an ERI test with this testmod to help catch these problems</option>
@@ -211,7 +211,7 @@
   <test name="SMS_D_Ld5" grid="f10_f10_ais8gris4_mg37" compset="I1850Clm50SpGag" testmods="cism/test_coupling">
     <machines>
 
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">0:30:00</option>
           <option name="comment">Include a short debug I compset test with both Antarctica and Greenland (basically duplicates a test on izumi, so we don't need to do baseline comparisons on izumi)</option>
@@ -223,7 +223,7 @@
 
   <test name="SMS_D_Ly1" grid="f09_tn14_gris4" compset="T1850Gg" testmods="cism/isostasy_period1">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">0:20</option>
           <option name="comment">Include a debug test with isostasy turned on</option>
@@ -234,7 +234,7 @@
 
   <test name="SMS_D_Ly1" grid="f09_tn14_gris4" compset="T1850Gg">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">0:20</option>
         </options>
@@ -249,7 +249,7 @@
 
   <test name="SMS_D_Ly1" grid="f09_tn14_ais8" compset="T1850Ga">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">0:20</option>
           <option name="comment">include a debug T compset test with Antarctica, gnu compiler (currently changed to intel for betzy)</option>
@@ -266,7 +266,7 @@
 
   <test name="ERS_Ly5" grid="f09_tn14_gris4" compset="T1850Gg" testmods="cism/isostasy_period4">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">1:30</option>
           <option name="comment">Include an exact restart test with isostasy, where we restart in the middle of the isostasy update period</option>
@@ -277,7 +277,7 @@
 
   <test name="ERS_Ly3" grid="f09_tn14_gris4" compset="T1850Gg" testmods="cism/isostasy_period1">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">0:50</option>
           <option name="comment">Include an exact restart test with isostasy, where restart aligns with the isostasy update period</option>
@@ -288,7 +288,7 @@
 
   <test name="SMS_Lm13" grid="f10_f10_mg37" compset="I1850Clm50SpG" testmods="cism/noevolve">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">2:00</option>
           <option name="comment">Include an I compset test with CISM in NOEVOLVE mode. The purpose of this test is: Often there are answer changes in CISM, but we expect that these should not affect NOEVOLVE runs (which is the typical CESM configuration). This test allows us to do a baseline comparison to confirm that expectation. 13-months rather than 1-year in order to allow time for CISM to affect CLM (and CLM to produce the next month's history file).</option>
@@ -299,7 +299,7 @@
 
   <test name="ERS_D_Ly3" grid="f09_tn14_ais8gris4" compset="T1850Gag">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">1:00:00</option>
           <option name="comment">Include an ERS_D test with multiple ice sheets</option>
@@ -310,7 +310,7 @@
 
   <test name="ERI_Ly9" grid="f09_tn14_ais8gris4" compset="T1850Gag" testmods="cism-noevolve_ais">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">0:50:00</option>
           <option name="comment">ERI test with one ice sheet evolving and the other not, to make sure restart, branch and hybrid runs all work when one ice sheet is evolving and another is not.</option>
@@ -335,7 +335,7 @@
   -->
   <test name="MULTINOAIS_Ly2" grid="f10_f10_ais8gris4_mg37" compset="I1850Clm50SpRsGag" testmods="cism/change_params">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">1:50:00</option>
           <option name="comment">Compare a run with Antarctica and Greenland against a run with just Greenland; Greenland should be bit-for-bit in the two runs. Using an I compset test to exercise smb renormalization as well as code related to glc -> lnd coupling. The use of the change_params testmod is not critical for this test, but this test is a useful one for exercising that testmod.</option>
@@ -352,7 +352,7 @@
   </test>
   <test name="MULTINOGRIS_Ly2" grid="f10_f10_ais8gris4_mg37" compset="I1850Clm50SpRsGag" testmods="cism/change_params">
     <machines>
-      <machine name="betzy" compiler="intel" category="aux_glc_noresm">
+      <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
           <option name="wallclock">1:50:00</option>
           <option name="comment">Compare a run with Antarctica and Greenland against a run with just Antarctica; Antarctica should be bit-for-bit in the two runs. Using an I compset test to exercise smb renormalization as well as code related to glc -> lnd coupling. The use of the change_params testmod is not critical for this test, but this test is a useful one for exercising that testmod.</option>

--- a/cime_config/testdefs/testlist_cism.xml
+++ b/cime_config/testdefs/testlist_cism.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <testlist version="2.0">
 
-  <test name="ERI_Ly44" grid="f09_tn14_gris20" compset="T1850Gg" testmods="cism/isostasy_period4">
+  <test name="ERI_Ly44" grid="f09_g17_gris20" compset="T1850Gg" testmods="cism/isostasy_period4">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -12,7 +12,7 @@
     </machines>
   </test>
 
-  <test name="ERI_Ly15" grid="f09_tn14_gris4" compset="T1850Gg" testmods="cism/isostasy_period4">
+  <test name="ERI_Ly15" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/isostasy_period4">
     <machines>
       <machine name="betzy" compiler="intel" category="prebeta_noresm">
         <options>
@@ -39,7 +39,7 @@
     </machines>
   </test>
 
-  <test name="ERS_Ly11" grid="f09_tn14_gris20" compset="T1850Gg">
+  <test name="ERS_Ly11" grid="f09_g17_gris20" compset="T1850Gg">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -49,7 +49,7 @@
     </machines>
   </test>
 
-  <test name="ERS_Ly11" grid="f09_tn14_gris20" compset="T1850Gg" testmods="cism/oneway">
+  <test name="ERS_Ly11" grid="f09_g17_gris20" compset="T1850Gg" testmods="cism/oneway">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -65,7 +65,7 @@
        that lnd_cpl_time equal glc_cpl_time". If I remember correctly,
        Mariana Vertenstein has fixed this issue on a branch of CMEPS.
        Once it is working, we should restore this test. -->
-  <test name="ERS_D_Ly3" grid="f09_tn14_gris4" compset="T1850Gg" testmods="cism/noevolve">
+  <test name="ERS_D_Ly3" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/noevolve">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -76,7 +76,7 @@
     </machines>
   </test>
 
-  <test name="ERS_Ly7" grid="f09_tn14_gris4" compset="T1850Gg">
+  <test name="ERS_Ly7" grid="f09_g17_gris4" compset="T1850Gg">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -92,7 +92,7 @@
     </machines>
   </test>
 
-  <test name="ERS_Ly5" grid="f09_tn14_ais8" compset="T1850Ga">
+  <test name="ERS_Ly5" grid="f09_g17_ais8" compset="T1850Ga">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -103,7 +103,7 @@
     </machines>
   </test>
 
-  <test name="ERS_D_Ly3" grid="f09_tn14_gris4" compset="T1850Gg" testmods="cism/cmip6_evolving_icesheet">
+  <test name="ERS_D_Ly3" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/cmip6_evolving_icesheet">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -221,7 +221,7 @@
     </machines>
   </test>
 
-  <test name="SMS_D_Ly1" grid="f09_tn14_gris4" compset="T1850Gg" testmods="cism/isostasy_period1">
+  <test name="SMS_D_Ly1" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/isostasy_period1">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -232,7 +232,7 @@
     </machines>
   </test>
 
-  <test name="SMS_D_Ly1" grid="f09_tn14_gris4" compset="T1850Gg">
+  <test name="SMS_D_Ly1" grid="f09_g17_gris4" compset="T1850Gg">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -247,7 +247,7 @@
     </machines>
   </test>
 
-  <test name="SMS_D_Ly1" grid="f09_tn14_ais8" compset="T1850Ga">
+  <test name="SMS_D_Ly1" grid="f09_g17_ais8" compset="T1850Ga">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -264,7 +264,7 @@
     </machines>
   </test>
 
-  <test name="ERS_Ly5" grid="f09_tn14_gris4" compset="T1850Gg" testmods="cism/isostasy_period4">
+  <test name="ERS_Ly5" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/isostasy_period4">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -275,7 +275,7 @@
     </machines>
   </test>
 
-  <test name="ERS_Ly3" grid="f09_tn14_gris4" compset="T1850Gg" testmods="cism/isostasy_period1">
+  <test name="ERS_Ly3" grid="f09_g17_gris4" compset="T1850Gg" testmods="cism/isostasy_period1">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -297,7 +297,7 @@
     </machines>
   </test>
 
-  <test name="ERS_D_Ly3" grid="f09_tn14_ais8gris4" compset="T1850Gag">
+  <test name="ERS_D_Ly3" grid="f09_g17_ais8gris4" compset="T1850Gag">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -308,7 +308,7 @@
     </machines>
   </test>
 
-  <test name="ERI_Ly9" grid="f09_tn14_ais8gris4" compset="T1850Gag" testmods="cism-noevolve_ais">
+  <test name="ERI_Ly9" grid="f09_g17_ais8gris4" compset="T1850Gag" testmods="cism-noevolve_ais">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -370,7 +370,7 @@
        ice sheets.
   -->
 
-  <test name="SMS_Ly2" grid="f09_tn14_gris20" compset="T1850Gg">
+  <test name="SMS_Ly2" grid="f09_g17_gris20" compset="T1850Gg">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cime_baselines">
         <options>

--- a/cime_config/testdefs/testlist_cism.xml
+++ b/cime_config/testdefs/testlist_cism.xml
@@ -28,7 +28,7 @@
     </machines>
   </test>
 
-  <test name="ERS_D_Ld9" grid="f10_f10_mg37" compset="I1850Clm50SpG" testmods="cism/override_glc_frac">
+  <test name="ERS_D_Ld9" grid="f19_f19_mtn14" compset="I1850Clm50SpG" testmods="cism/override_glc_frac">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -114,7 +114,7 @@
     </machines>
   </test>
 
-  <test name="ERS_Ly3" grid="f10_f10_mg37" compset="I1850Clm50SpG">
+  <test name="ERS_Ly3" grid="f19_f19_mtn14" compset="I1850Clm50SpG">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -131,7 +131,7 @@
     </machines>
   </test>
 
-  <test name="ERS_Ly3" grid="f10_f10_ais8_mg37" compset="I1850Clm50SpGa">
+  <test name="ERS_Ly3" grid="f19_f19_ais8_mtn14" compset="I1850Clm50SpGa">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -149,7 +149,7 @@
     </machines>
   </test>
 
-  <test name="SMS_Lm13" grid="f10_f10_mg37" compset="I1850Clm50SpG">
+  <test name="SMS_Lm13" grid="f19_f19_mtn14" compset="I1850Clm50SpG">
     <machines>
       <machine name="betzy" compiler="intel" category="prealpha_noresm">
         <options>
@@ -160,7 +160,7 @@
     </machines>
   </test>
 
-  <test name="ERS_Lm24" grid="f10_f10_ais8gris4_mg37" compset="I1850Clm50SpGag">
+  <test name="ERS_Lm24" grid="f19_f19_ais8gris4_mtn14" compset="I1850Clm50SpGag">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -179,7 +179,7 @@
     </machines>
   </test>
 
-  <test name="ERI_Lm24" grid="f10_f10_mg37" compset="I1850Clm50SpG" testmods="cism/isostasy_period4">
+  <test name="ERI_Lm24" grid="f19_f19_mtn14" compset="I1850Clm50SpG" testmods="cism/isostasy_period4">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -197,7 +197,7 @@
     </machines>
   </test>
 
-  <test name="ERI" grid="f10_f10_mg37" compset="I1850Clm50SpG" testmods="cism/test_coupling">
+  <test name="ERI" grid="f19_f19_mtn14" compset="I1850Clm50SpG" testmods="cism/test_coupling">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -208,7 +208,7 @@
     </machines>
   </test>
 
-  <test name="SMS_D_Ld5" grid="f10_f10_ais8gris4_mg37" compset="I1850Clm50SpGag" testmods="cism/test_coupling">
+  <test name="SMS_D_Ld5" grid="f19_f19_ais8gris4_mtn14" compset="I1850Clm50SpGag" testmods="cism/test_coupling">
     <machines>
 
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
@@ -286,7 +286,7 @@
     </machines>
   </test>
 
-  <test name="SMS_Lm13" grid="f10_f10_mg37" compset="I1850Clm50SpG" testmods="cism/noevolve">
+  <test name="SMS_Lm13" grid="f19_f19_mtn14" compset="I1850Clm50SpG" testmods="cism/noevolve">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -333,7 +333,7 @@
        much code at that point. See the comments at the top of
        multivssingle.py for more thoughts on this.
   -->
-  <test name="MULTINOAIS_Ly2" grid="f10_f10_ais8gris4_mg37" compset="I1850Clm50SpRsGag" testmods="cism/change_params">
+  <test name="MULTINOAIS_Ly2" grid="f19_f19_ais8gris4_mtn14" compset="I1850Clm50SpRsGag" testmods="cism/change_params">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -350,7 +350,7 @@
 
     </machines>
   </test>
-  <test name="MULTINOGRIS_Ly2" grid="f10_f10_ais8gris4_mg37" compset="I1850Clm50SpRsGag" testmods="cism/change_params">
+  <test name="MULTINOGRIS_Ly2" grid="f19_f19_ais8gris4_mtn14" compset="I1850Clm50SpRsGag" testmods="cism/change_params">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cism_noresm">
         <options>
@@ -380,7 +380,7 @@
     </machines>
   </test>
 
-  <test name="SMS_Ld5" grid="f10_f10_ais8gris4_mg37" compset="I1850Clm50SpGag" testmods="cism/test_coupling">
+  <test name="SMS_Ld5" grid="f19_f19_ais8gris4_mtn14" compset="I1850Clm50SpGag" testmods="cism/test_coupling">
     <machines>
       <machine name="betzy" compiler="intel" category="aux_cime_baselines">
         <options>


### PR DESCRIPTION
This PR creates a new testlist for CISM_wrapper and updated PES to run on betzy.

The NorESM/CIME testing documention is here
https://noresm-docs.readthedocs.io/en/noresm2/testing/systemtests.html

Testing on betzy is in progress and this PR will be moved from draft to review once the testing is done.

The following test suite  was run and new baselines were created in 

`/cluster/shared/noresm/noresm_baselines/cismwrap_2_1_97_noresm_v2 `

`./create_test -o --xml-category aux_cism_noresm --generate  ismwrap_2_1_97_noresm_v2  --baseline-root /cluster/shared/noresm/noresm_baselines --project <your project>`

The following tests have been added for betzy for category aux_cism_noresm:
To see this you can invoke the following from $SRCROOT/cime/scripts
`> ./query_config --xml-category aux_cism_noresm`

NOTE that T compsets must have the ocean resolution/mask at g17 since they are being forced with DLND forcing that assumes a gx1v7 ocean grid/mask.

```python
aux_cism_noresm: ERI_Ly44.f09_g17_gris20.T1850Gg.betzy_intel.cism-isostasy_period4                        # include a longer ERI test to catch problems that may just show up after longer runs, using a coarse resolution to get faster turnaround and lower cost; include isostasy because there are extra subtleties with getting isostasy to restart exactly
aux_cism_noresm: ERI_Ly15.f09_g17_gris4.T1850Gg.betzy_intel.cism-isostasy_period4                         # include an ERI test at the production resolution, to exercise all options used at that resolution; include isostasy because there are extra subtleties with getting isostasy to restart exactly
aux_cism_noresm: ERS_D_Ld9.f19_f19_mtn14.I1850Clm50SpG.betzy_intel.cism-override_glc_frac                 # Make sure glc override options work correctly, and restart properly. Note that we do not generate cism history files in this test, but that is okay: this test is about what is sent to the coupler, not what is output by CISM. (And currently CISM history files do not restart properly in this test.)
aux_cism_noresm: ERS_Ly11.f09_g17_gris20.T1850Gg.betzy_intel
aux_cism_noresm: ERS_Ly11.f09_g17_gris20.T1850Gg.betzy_intel.cism-oneway                                  # (3-3-16) identical to an existing non-oneway test, which generates some non-zero runoff fluxes
aux_cism_noresm: ERS_D_Ly3.f09_g17_gris4.T1850Gg.betzy_intel.cism-noevolve                                # ice evolution off is the typical operation of cism within cesm, so test that configuration
aux_cism_noresm: ERS_Ly7.f09_g17_gris4.T1850Gg.betzy_intel                                                # include one ERS test of the typical production resolution for CISM2
aux_cism_noresm: ERS_Ly5.f09_g17_ais8.T1850Ga.betzy_intel                                                 # include a non-debug T compset test of Antarctica
aux_cism_noresm: ERS_D_Ly3.f09_g17_gris4.T1850Gg.betzy_intel.cism-cmip6_evolving_icesheet                 # Want both an ERS test and a _D test that include the cmip6_evolving_icesheet usermods
aux_cism_noresm: ERS_Ly3.f19_f19_mtn14.I1850Clm50SpG.betzy_intel                                          # Need IG ERS test to catch problems with fields sent before the end of the first year after restart.
aux_cism_noresm: ERS_Ly3.f19_f19_ais8_mtn14.I1850Clm50SpGa.betzy_intel                                    # include a multi-year I compset test with Antarctica
aux_cism_noresm: ERS_Lm24.f19_f19_ais8gris4_mtn14.I1850Clm50SpGag.betzy_intel                             # Mid-year exact restart test. Also covers multiple ice sheets in a multi-year I compset test.
aux_cism_noresm: ERI_Lm24.f19_f19_mtn14.I1850Clm50SpG.betzy_intel.cism-isostasy_period4                   # Test branching mid-year; include isostasy because there are extra subtleties with getting isostasy to restart exactly
aux_cism_noresm: ERI.f19_f19_mtn14.I1850Clm50SpG.betzy_intel.cism-test_coupling                           # Changes often break the test_coupling testmod, so include an ERI test with this testmod to help catch these problems
aux_cism_noresm: SMS_D_Ld5.f19_f19_ais8gris4_mtn14.I1850Clm50SpGag.betzy_intel.cism-test_coupling         # Include a short debug I compset test with both Antarctica and Greenland (basically duplicates a test on izumi, so we don't need to do baseline comparisons on izumi)
aux_cism_noresm: SMS_D_Ly1.f09_g17_gris4.T1850Gg.betzy_intel.cism-isostasy_period1                        # Include a debug test with isostasy turned on
aux_cism_noresm: SMS_D_Ly1.f09_g17_gris4.T1850Gg.betzy_intel
aux_cism_noresm: SMS_D_Ly1.f09_g17_ais8.T1850Ga.betzy_intel                                               # include a debug T compset test with Antarctica, gnu compiler (currently changed to intel for betzy)
aux_cism_noresm: ERS_Ly5.f09_g17_gris4.T1850Gg.betzy_intel.cism-isostasy_period4                          # Include an exact restart test with isostasy, where we restart in the middle of the isostasy update period
aux_cism_noresm: ERS_Ly3.f09_g17_gris4.T1850Gg.betzy_intel.cism-isostasy_period1                          # Include an exact restart test with isostasy, where restart aligns with the isostasy update period
aux_cism_noresm: SMS_Lm13.f19_f19_mtn14.I1850Clm50SpG.betzy_intel.cism-noevolve                           # Include an I compset test with CISM in NOEVOLVE mode. The purpose of this test is: Often there are answer changes in CISM, but we expect that these should not affect NOEVOLVE runs (which is the typical CESM configuration). This test allows us to do a baseline comparison to confirm that expectation. 13-months rather than 1-year in order to allow time for CISM to affect CLM (and CLM to produce the next month's history file).
aux_cism_noresm: ERS_D_Ly3.f09_g17_ais8gris4.T1850Gag.betzy_intel                                         # Include an ERS_D test with multiple ice sheets
aux_cism_noresm: ERI_Ly9.f09_g17_ais8gris4.T1850Gag.betzy_intel.cism-noevolve_ais                         # ERI test with one ice sheet evolving and the other not, to make sure restart, branch and hybrid runs all work when one ice sheet is evolving and another is not.
aux_cism_noresm: MULTINOAIS_Ly2.f19_f19_ais8gris4_mtn14.I1850Clm50SpRsGag.betzy_intel.cism-change_params  # Compare a run with Antarctica and Greenland against a run with just Greenland; Greenland should be bit-for-bit in the two runs. Using an I compset test to exercise smb renormalization as well as code related to glc -> lnd coupling. The use of the change_params testmod is not critical for this test, but this test is a useful one for exercising that testmod.
aux_cism_noresm: MULTINOGRIS_Ly2.f19_f19_ais8gris4_mtn14.I1850Clm50SpRsGag.betzy_intel.cism-change_params # Compare a run with Antarctica and Greenland against a run with just Antarctica; Antarctica should be bit-for-bit in the two runs. Using an I compset test to exercise smb renormalization as well as code related to glc -> lnd coupling. The use of the change_params testmod is not critical for this test, but this test is a useful one for exercising that testmod.
```

The following test fails - ERS_D_Ly3.f09_g17_ais8gris4.T1850Gag.betzy_intel - but it seems that this is because the test itself does not label the restart file correctly. Otherwise all tests passed.

To check out the code that allows the testing do the following:

```bash
> git clone git clone https://github.com/mvertens/NorESM.git noresm2_5_alpha01_cism
> cd noresm2_5_alpha01_cism
> git checkout feature/add_cism_updates
> ./manage_externals/checkout_externals -v
> cd cime/scripts
```

If you want to compare against the baselines created - you can issue the following

`./create_test --xml-category aux_cism_noresm --compare cismwrap_2_1_97_noresm_v2 --baseline-root /cluster/shared/noresm/noresm_baselines --project <your_project>`