### PR TITLE
update namelist to suppress elevation classes

### DIFF
--- a/cime_config/namelist_definition_cism.xml
+++ b/cime_config/namelist_definition_cism.xml
@@ -2831,6 +2831,21 @@ Sub-elements of each entry include:
       Default: 0 for Greenland, 0 for Antarctica
     </desc>
   </entry>
+
+     <entry id="use_ec_update">
+    <type>integer</type>
+    <category>cism_config_ho_options</category>
+    <group>ho_options</group>
+    <values>
+      <value icesheet="gris">1</value>
+      <value icesheet="ais" >1</value>
+    </values>
+    <desc> Flag that indicates whether or not update SMB for EC changes in
+      fully coupled or T-compset mode. 0=no EC, 1=use EC,
+      Default: 1 for Greenland, 1 for Antarctica
+    </desc>
+  </entry>
+
  
   <!-- =============================================================  -->
   <!-- group: cism.icesheet.config: GTHF (geothermal heat flux)       -->


### PR DESCRIPTION
Update the namelist to support changes in source_cism to run inversion spin-up within T-compset