### PR TITLE
Add frontal_melt_factor to CISM configuration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 [submodule "source_cism"]
 path = source_cism
 url = https://github.com/NorESMhub/CISM
-fxtag = cism_main_2.01.017_noresm_v4
+fxtag = cism_main_2.01.017_noresm_v5
 fxrequired = AlwaysRequired
 fxDONOTUSEurl = https://github.com/NorESMhub/CISM
 

--- a/cime_config/namelist_definition_cism.xml
+++ b/cime_config/namelist_definition_cism.xml
@@ -903,6 +903,21 @@ Sub-elements of each entry include:
     </desc>
   </entry>
 
+  <entry id="frontal_melt_factor">
+    <type>real</type>
+    <category>cism_config_options</category>
+    <group>options</group>
+    <values>
+      <value icesheet="gris">1.0</value>
+      <value icesheet="ais" >1.0</value>
+    </values>
+    <desc>
+      Multiplier for Rignot frontal melt parameterisation. 
+	  May be used for sampling uncertainty in the parameterisation and to correct for resolution depencence
+      Default: 1.0 
+    </desc>
+  </entry>
+
   <entry id="calving_domain">
     <type>integer</type>
     <category>cism_config_options</category>


### PR DESCRIPTION
Here is the corresponding PR to https://github.com/NorESMhub/CISM/pull/12
Add namelist parameter 'frontal_melt_factor' to control CISM ocean melt parameterisation.

I have run the standard tests suite aux_cism_noresm with all passes. Comparison to the baseline show differences as expected.
