### PR TITLE
Change group from 'options' to 'parameters' for frontal_melt_factor

### DIFF
--- a/cime_config/namelist_definition_cism.xml
+++ b/cime_config/namelist_definition_cism.xml
@@ -906,7 +906,7 @@ Sub-elements of each entry include:
   <entry id="frontal_melt_factor">
     <type>real</type>
     <category>cism_config_options</category>
-    <group>options</group>
+    <group>parameters</group>
     <values>
       <value icesheet="gris">1.0</value>
       <value icesheet="ais" >1.0</value>


### PR DESCRIPTION
This PR fixes a bug preventing frontal_melt_factor to be picked up by cism. 
Submitted without rerunning tests, because change is clear and has no other implications.
Can we add this to the list for beta19?